### PR TITLE
Avoid scientific notation for small values

### DIFF
--- a/components/Trade/Advanced/TradingPanel/PostTradeDetails.tsx
+++ b/components/Trade/Advanced/TradingPanel/PostTradeDetails.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { toApproxCurrency } from '@libs/utils';
+import { isVerySmall, toApproxCurrency } from '@libs/utils';
 import {
     calcBorrowed,
     calcLeverage,
@@ -51,7 +51,7 @@ const PostTradeDetails: React.FC<PTDProps> = styled(
                 </Section>
                 <Section label={'Leverage'}>
                     <Previous>{calcLeverage(balances.quote, balances.base, fairPrice).toPrecision(3)}</Previous>
-                    {calcLeverage(newQuote, newBase, fairPrice).toPrecision(3)}
+                    {isVerySmall(calcLeverage(newQuote, newBase, fairPrice), false)}
                 </Section>
             </div>
         );

--- a/libs/utils/converters.ts
+++ b/libs/utils/converters.ts
@@ -61,3 +61,20 @@ export const timeAgo: (current: number, previous: number) => string = (current, 
         return Math.round(elapsed / msPerYear) + 'y';
     }
 };
+
+export const isVerySmall: (num: BigNumber, currency: boolean) => string = (num, currency) => {
+    const isSmall = num.lt(0.000001); // some arbitrarily small number
+    if (currency) {
+        if (isSmall) {
+            return `≈ ${toApproxCurrency(0)}`;
+        } else {
+            return toApproxCurrency(num);
+        }
+    } else {
+        if (isSmall) {
+            return `≈ ${num.toFixed(4)}`;
+        } else {
+            return `${num.toFixed(4)}`;
+        }
+    }
+};

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,4 +1,4 @@
-// // in your node script before running whatever is causing the warnings
+// prevent creating full trace
 process.traceDeprecation = true;
 
 import React from 'react';
@@ -13,7 +13,7 @@ import { Notification } from '@components/General/Notification';
 import { TransactionStore } from '@context/TransactionContext';
 import { FactoryStore } from '@context/FactoryContext';
 
-const App = ({ Component, pageProps }: AppProps) => { //eslint-disable-line
+const App = ({ Component, pageProps }: AppProps) => { // eslint-disable-line
     return (
         <div>
             <Head>


### PR DESCRIPTION
### Motivation
- calculating post trade leverage was displaying scientific notation when leverage was extremely small#21 

### Changes
- add an isVerySmall function which can be used when you expect  values to be potentially very smalls.
- appends the approx equal sign to the front of the string