### PR TITLE
Avoid 0 initial value

### DIFF
--- a/components/Trade/Advanced/TradingPanel/Account.tsx
+++ b/components/Trade/Advanced/TradingPanel/Account.tsx
@@ -158,7 +158,7 @@ const Popup: React.FC<PProps> = styled(
             deposit = () => console.error('Deposit is not defined'),
             withdraw = () => console.error('Withdraw is not defined'),
         } = useContext(TracerContext);
-        const [amount, setAmount] = useState(0);
+        const [amount, setAmount] = useState(NaN);
         const available = isDeposit
             ? balances.tokenBalance
             : calcTotalMargin(balances.quote, balances.base, price).minus(

--- a/components/Trade/Advanced/TradingPanel/Inputs.tsx
+++ b/components/Trade/Advanced/TradingPanel/Inputs.tsx
@@ -14,6 +14,7 @@ interface ISProps {
 export const Inputs: React.FC<ISProps> = ({ selectedTracer, amount, price }: ISProps) => {
     const { orderDispatch } = useContext(OrderContext);
     const tracerId = selectedTracer?.marketId ?? '';
+    console.log(amount, price);
     const balances = selectedTracer?.balances ?? defaults.balances;
     const fairPrice = selectedTracer?.oraclePrice ?? defaults.oraclePrice;
     const maxMargin = calcWithdrawable(

--- a/context/OrderContext.tsx
+++ b/context/OrderContext.tsx
@@ -146,7 +146,7 @@ export const OrderStore: React.FC<Children> = ({ children }: Children) => {
         orderBase: 0, // required margin / amount of margin being used
         leverage: 0,
         position: 0, // long or short, 0 is short, 1 is long
-        price: 0, // price of the market asset in relation to the collateral asset
+        price: NaN, // price of the market asset in relation to the collateral asset
         matchingEngine: 0, // for basic this will always be 0 (OME)
         orderType: 0, // for basic this will always be 0 (market order), 1 is limit and 2 is spot
         openOrders: {
@@ -243,7 +243,9 @@ export const OrderStore: React.FC<Children> = ({ children }: Children) => {
         if (order.orderType === 0) {
             const { exposure, tradePrice } = calcTradeExposure(order.orderBase, order.leverage, oppositeOrders);
             orderDispatch({ type: 'setExposure', value: exposure });
-            orderDispatch({ type: 'setPrice', value: tradePrice.toNumber() });
+            if (!!tradePrice.toNumber()) {
+                orderDispatch({ type: 'setPrice', value: tradePrice.toNumber() });
+            }
         }
     }, [order.orderBase, order.leverage, oppositeOrders]);
 

--- a/libs/utils/converters.ts
+++ b/libs/utils/converters.ts
@@ -69,13 +69,13 @@ export const timeAgo: (current: number, previous: number) => string = (current, 
 export const isVerySmall: (num: BigNumber, currency: boolean) => string = (num, currency) => {
     const isSmall = num.lt(0.000001); // some arbitrarily small number
     if (currency) {
-        if (isSmall) {
+        if (isSmall && num.eq(0)) {
             return `≈ ${toApproxCurrency(0)}`;
         } else {
             return toApproxCurrency(num);
         }
     } else {
-        if (isSmall) {
+        if (isSmall && !num.eq(0)) {
             return `≈ ${num.toFixed(4)}`;
         } else {
             return `${num.toFixed(4)}`;


### PR DESCRIPTION
### Motivation
- input values were displaying their 0 value as opposed to their place holder 0.0

### Changes
- avoid setting to 0 as initial value, set as NaN instead