### PR TITLE
Etherscan Link for iPoolToken

### DIFF
--- a/components/Insurance/Pools/index.tsx
+++ b/components/Insurance/Pools/index.tsx
@@ -5,11 +5,13 @@ import { InsurancePoolInfo, InsurancePoolInfo as InsurancePoolInfoType } from 't
 import styled from 'styled-components';
 import { ProgressBar } from '@components/General';
 import { Button, Logo } from '@components/General';
-import { CaretDownFilled } from '@ant-design/icons';
+import { CaretDownFilled, LinkOutlined } from '@ant-design/icons';
 import Breakdown from '../PoolHealth/Breakdown';
 import { InsuranceModal } from '../InsuranceModal';
 import { TableHead, TableRow, TableCell, SecondaryCell } from '@components/Portfolio';
 import { toPercent } from '@libs/utils';
+import Link from 'next/link';
+import { StyledTooltip } from '@components/Tooltips';
 
 const Hidden = styled.div`
     color: #3da8f5;
@@ -77,8 +79,13 @@ const OwnershipCell: React.FC<CProps> = styled(({ pool, className }: CProps) => 
     return (
         <div className={className}>
             <span>
-                {pool.userBalance.toNumber()} {pool.market}
+                {pool.userBalance.toNumber()} {pool.iPoolTokenName} 
             </span>
+            <Link href={pool.iPoolTokenURL}>
+            <StyledTooltip title="View on Etherscan">
+                <LinkOutlined style={{margin: '5px', marginBottom:'2px'}}/>
+            </StyledTooltip>
+            </Link>
             <SecondaryCell>{pool.userBalance.div(pool.liquidity).precision(5).toNumber() * 100}%</SecondaryCell>
             <Hidden>
                 <ButtonContainer>

--- a/context/InsuranceContext.tsx
+++ b/context/InsuranceContext.tsx
@@ -58,7 +58,7 @@ interface State {
 export const InsuranceContext = React.createContext<Partial<ContextProps>>({});
 
 export const InsuranceStore: React.FC<Children> = ({ children }: Children) => {
-    const { account, web3 } = useContext(Web3Context);
+    const { account, web3, config } = useContext(Web3Context);
     const { factoryState: { tracers } = initialFactoryState } = useContext(FactoryContext);
     const { selectedTracer } = useContext(TracerContext);
     const { handleTransaction } = useContext(TransactionContext);
@@ -195,6 +195,11 @@ export const InsuranceStore: React.FC<Children> = ({ children }: Children) => {
             const liquidity = res[3] ? new BigNumber(Web3.utils.fromWei(res[3])) : defaults.liquidity;
             const target = res[2] ? new BigNumber(Web3.utils.fromWei(res[2])) : defaults.target;
             const health = liquidity.div(target);
+            let splitId = marketId.split("/")
+            const iPoolTokenName = `i${splitId[0]}-${splitId[1]}`
+            const iTokenAddress = await contract?.methods.token().call()
+            const iTokenURL = `${config?.previewUrl}/address/${iTokenAddress}`
+            // const etherscanLink = `https://${network}.etherscan.io/address/${iTokenAddress}`
             dispatch({
                 type: 'setAll',
                 marketId: marketId,
@@ -207,6 +212,8 @@ export const InsuranceStore: React.FC<Children> = ({ children }: Children) => {
                     health: health.lt(1) ? health.times(100) : defaults.health,
                     apy: defaults.apy,
                     buffer: res[4] ? new BigNumber(Web3.utils.fromWei(res[4])) : defaults.buffer,
+                    iPoolTokenURL: iTokenURL,
+                    iPoolTokenName: iPoolTokenName
                 },
             });
         } // else

--- a/types/InsuranceTypes.ts
+++ b/types/InsuranceTypes.ts
@@ -33,4 +33,6 @@ export type InsurancePoolInfo = {
     health: BigNumber;
     apy: BigNumber;
     buffer: BigNumber;
+    iPoolTokenURL: string;
+    iPoolTokenName: string
 };


### PR DESCRIPTION
### Motivation
Adds an Etherscan link for the iPoolToken so users can view the token more easily.



### Changes
- alter `insurancePoolInfo` type to support poolToken name and url
- render a tooltip and etherscan link on the insurance pools page
