### PR TITLE
Lmdevs 488 remove hidden market dropdown overlap

### DIFF
--- a/components/Trade/Advanced/TradingPanel/MarketSelect/index.tsx
+++ b/components/Trade/Advanced/TradingPanel/MarketSelect/index.tsx
@@ -147,7 +147,7 @@ export default styled(({ className }: MSProps) => {
     }, [popup]);
 
     return (
-        <div className={className}>
+        <div className={`${className}`}>
             <SBox color={popup ? '#011772' : '#000240'} display={popup} onMouseLeave={() => setPopup(false)}>
                 <MarketContainer>
                     <SLogo ticker={selectedTracer?.baseTicker ?? 'ETH'} />

--- a/components/Trade/Advanced/TradingPanel/TradingInput/ModifyOrder.tsx
+++ b/components/Trade/Advanced/TradingPanel/TradingInput/ModifyOrder.tsx
@@ -145,6 +145,7 @@ export default styled(({ selectedTracer, className, account }: TIProps) => {
     display: block;
     padding: 0;
     height: 100%;
+    z-index: 1;
     &.hide {
         height: 0;
         padding: 0;

--- a/components/Trade/Advanced/TradingPanel/TradingInput/PlaceOrder.tsx
+++ b/components/Trade/Advanced/TradingPanel/TradingInput/PlaceOrder.tsx
@@ -170,6 +170,7 @@ export default styled(({ selectedTracer, className, account }: TIProps) => {
     display: block;
     padding: 0;
     height: 100%;
+    z-index: 1;
     &.hide {
         height: 0;
         padding: 0;


### PR DESCRIPTION
### Motivation

- dropdown was causing weird behaviour when clicking around the order inputs


### Changes

- add a z-index to input components to prevent dropdown overlap
