### PR TITLE
trueMaxLeverage instead of maxLeverage

### DIFF
--- a/libs/Tracer/index.tsx
+++ b/libs/Tracer/index.tsx
@@ -118,7 +118,7 @@ export default class Tracer {
         const tokenAddr = this._instance.methods.tracerQuoteToken().call();
         const quoteTokenDecimals = this._instance.methods.quoteTokenDecimals().call();
         const liquidationGasCost = this._instance.methods.LIQUIDATION_GAS_COST().call();
-        const maxLeverage = this._instance.methods.maxLeverage().call();
+        const maxLeverage = this._instance.methods.trueMaxLeverage().call();
         const fundingRateSensitivity = this._instance.methods.fundingRateSensitivity().call();
         const feeRate = this._instance.methods.feeRate().call();
         const insuranceContract = this._instance.methods.insuranceContract().call();


### PR DESCRIPTION
### Motivation
`TracerPerpetualSwaps.trueMaxLeverage()` is the actual max leverage that is used in calculations in smart contracts. It should be used in the front-end


### Changes

- changes `maxLeverage()` to `trueMaxLeverage()`
