### PR TITLE
Return the result message instead of the literal string

### DIFF
--- a/context/TracerContext.tsx
+++ b/context/TracerContext.tsx
@@ -139,7 +139,7 @@ export const SelectedTracerStore: React.FC<StoreProps> = ({ tracer, children }: 
             }
             return {
                 status: res.status,
-                message: 'Successfully matched order',
+                message: res.message,
             };
         } catch (err) {
             return { status: 'error', message: `Failed to place order ${err}` } as Result;


### PR DESCRIPTION
### Motivation

When you submit an order to the frontend and the OME rejects it, the message displayed is misleading.

### Changes

- Proposed change: return the message of the result
