### PR TITLE
Prevent graph crashing when changing networks

### DIFF
--- a/components/Charts/LightWeightChart.tsx
+++ b/components/Charts/LightWeightChart.tsx
@@ -88,14 +88,20 @@ const LightWeightChart: React.FC<{ candleData: CandleData }> = ({ candleData }) 
     }, []);
 
     useMemo(() => {
-        setGraphData({
-            ...setGraphOptions(),
-            candlestickSeries: [
-                {
-                    data: candleData,
-                },
-            ],
-        });
+        if (candleData.length) {
+            setGraphData({
+                ...setGraphOptions(),
+                candlestickSeries: [
+                    {
+                        data: candleData,
+                    },
+                ],
+            });
+        } else {
+            setGraphData({
+                ...setGraphOptions(),
+            });
+        }
     }, [candleData]);
 
     if (!graphData || !(graphData?.candlestickSeries as any[])?.length) {

--- a/components/Charts/LightWeightWrapper.tsx
+++ b/components/Charts/LightWeightWrapper.tsx
@@ -217,7 +217,9 @@ class ChartWrapper extends React.Component<Props> {
 
     handleTimeRange = () => {
         const { from, to } = this.props;
-        from && to && this.chart.timeScale().setVisibleRange({ from, to });
+        if (from && to && this.chart) {
+            this.chart.timeScale().setVisibleRange({ from, to });
+        }
     };
 
     handleLinearInterpolation = (data: any, candleTime: any) => {

--- a/hooks/TracerHooks.ts
+++ b/hooks/TracerHooks.ts
@@ -49,16 +49,16 @@ export const useTracerOrders: (web3: Web3 | undefined, tracer: Tracer | undefine
     const [contract, setContract] = useState<TracerType>();
 
     useEffect(() => {
-        if (web3 && tracer) {
+        if (web3 && tracer?.address) {
             setContract(new web3.eth.Contract(tracerJSON as AbiItem[], tracer.address) as unknown as TracerType);
         }
     }, [web3, tracer]);
     const [openOrders, setOpenOrders] = useState<Record<string, OpenOrder[]>>({ longOrders: [], shortOrders: [] });
 
     const getOpenOrders: () => Promise<Record<string, OpenOrder[]>> = async () => {
-        if (tracer) {
+        if (tracer?.address) {
             // does nothing for now
-            await getOrders(tracer.address);
+            await getOrders(tracer?.address);
         }
         return {
             shortOrders: [],


### PR DESCRIPTION
### Motivation

- changing networks was preventing the app to crash


### Changes

- remove setting of candleData when it is empty
- prevent fetching orders when tracer address is falsey
