### PR TITLE
Remove toast error for account fetching

### DIFF
--- a/libs/Graph/hooks/Tracer.ts
+++ b/libs/Graph/hooks/Tracer.ts
@@ -74,7 +74,7 @@ export const useMostRecentMatched: (tracer: string) => {
             }
             if (networkError) {
                
-            }
+            
         },
     });
 

--- a/libs/Graph/hooks/Tracer.ts
+++ b/libs/Graph/hooks/Tracer.ts
@@ -73,13 +73,7 @@ export const useMostRecentMatched: (tracer: string) => {
                 graphQLErrors.map((err) => console.error(`Failed to fetch tracer data: ${err}`));
             }
             if (networkError) {
-                console.error(
-                    ['Failed to fetch', `Failed to fetch account trades due to network error: ${networkError}`],
-                    {
-                        appearance: 'error',
-                        autoDismiss: true,
-                    },
-                );
+               
             }
         },
     });

--- a/libs/Graph/hooks/Tracer.ts
+++ b/libs/Graph/hooks/Tracer.ts
@@ -68,7 +68,7 @@ export const useMostRecentMatched: (tracer: string) => {
     const { data, error, loading, refetch } = useQuery(TRACER_TRADES, {
         variables: { tracer: tracer.toLowerCase() },
         errorPolicy: 'all',
-        onError: ({ graphQLErrors, networkError }) => {
+        onError: ({ graphQLErrors }) => {
             if (graphQLErrors) {
                 graphQLErrors.map((err) => console.error(`Failed to fetch tracer data: ${err}`));
             }

--- a/libs/Graph/hooks/Tracer.ts
+++ b/libs/Graph/hooks/Tracer.ts
@@ -72,7 +72,7 @@ export const useMostRecentMatched: (tracer: string) => {
             if (graphQLErrors) {
                 graphQLErrors.map((err) => console.error(`Failed to fetch tracer data: ${err}`));
             }
-            if (networkError) {
+          
                
             
         },

--- a/libs/Graph/hooks/Tracer.ts
+++ b/libs/Graph/hooks/Tracer.ts
@@ -1,7 +1,6 @@
 import { gql, useQuery } from '@apollo/client';
 import { FilledOrder } from 'types/OrderTypes';
 import { useRef } from 'react';
-import { useToasts } from 'react-toast-notifications';
 import Web3 from 'web3';
 import { CandleData } from 'types/TracerTypes';
 import { toBigNumbers } from '..';
@@ -66,7 +65,6 @@ export const useMostRecentMatched: (tracer: string) => {
     refetch: any;
 } = (tracer) => {
     const ref = useRef<FilledOrder[]>([]);
-    const { addToast } = useToasts();
     const { data, error, loading, refetch } = useQuery(TRACER_TRADES, {
         variables: { tracer: tracer.toLowerCase() },
         errorPolicy: 'all',
@@ -75,10 +73,13 @@ export const useMostRecentMatched: (tracer: string) => {
                 graphQLErrors.map((err) => console.error(`Failed to fetch tracer data: ${err}`));
             }
             if (networkError) {
-                addToast(['Failed to fetch', `Failed to fetch account trades due to network error: ${networkError}`], {
-                    appearance: 'error',
-                    autoDismiss: true,
-                });
+                console.error(
+                    ['Failed to fetch', `Failed to fetch account trades due to network error: ${networkError}`],
+                    {
+                        appearance: 'error',
+                        autoDismiss: true,
+                    },
+                );
             }
         },
     });


### PR DESCRIPTION
### Motivation

Users should not see an error the first time they use tracer.

### Changes

- Remove the addToast on error and replace it with a console.error
