### PR TITLE
Remove mark price

### DIFF
--- a/components/Portfolio/Trading/Position/index.tsx
+++ b/components/Portfolio/Trading/Position/index.tsx
@@ -26,7 +26,7 @@ const Position: React.FC<{
         'Realised P&L',
         'Margin Used',
         'Exposure',
-        'Liquidation Price/ Mark Price',
+        'Liquidation Price',
         'Status',
     ];
 

--- a/components/Trade/Advanced/RightPanel/AccountDetails/index.tsx
+++ b/components/Trade/Advanced/RightPanel/AccountDetails/index.tsx
@@ -129,12 +129,20 @@ const Leverage: React.FC<ContentProps & { fairPrice: BigNumber }> = ({
 interface IProps {
     balances: UserBalance;
     fairPrice: BigNumber;
+    lastPrice: number;
     maxLeverage: BigNumber;
     baseTicker: string;
     quoteTicker: string;
 }
 
-const PositionDetails: React.FC<IProps> = ({ balances, fairPrice, baseTicker, quoteTicker, maxLeverage }: IProps) => {
+const PositionDetails: React.FC<IProps> = ({
+    balances,
+    fairPrice,
+    lastPrice,
+    baseTicker,
+    quoteTicker,
+    maxLeverage,
+}: IProps) => {
     const { order } = useContext(OrderContext);
     const [currency, setCurrency] = useState(0); // 0 quoted in base
     const { base } = balances;
@@ -212,8 +220,8 @@ const PositionDetails: React.FC<IProps> = ({ balances, fairPrice, baseTicker, qu
                 >
                     {!balances.quote.eq(0) ? <Content>{toApproxCurrency(0)}</Content> : `-`}
                 </AccountDetailsSection>
-                <AccountDetailsSection label={'Mark Price'} className="w-1/2 border-right">
-                    {!balances.quote.eq(0) ? <Content>{toApproxCurrency(fairPrice)}</Content> : `-`}
+                <AccountDetailsSection label={'Last Price'} className="w-1/2 border-right">
+                    {!balances.quote.eq(0) ? <Content>{toApproxCurrency(lastPrice)}</Content> : `-`}
                 </AccountDetailsSection>
                 <AccountDetailsSection
                     label={'Realised PnL'}
@@ -364,6 +372,7 @@ export default styled(({ selectedTracer, className }: TSProps) => {
                     <PositionDetails
                         balances={balances}
                         fairPrice={fairPrice}
+                        lastPrice={omeState?.maxAndMins?.maxAsk ?? 0}
                         maxLeverage={selectedTracer?.maxLeverage ?? defaults.maxLeverage}
                         baseTicker={selectedTracer?.baseTicker ?? defaults.baseTicker}
                         quoteTicker={selectedTracer?.quoteTicker ?? defaults.quoteTicker}

--- a/components/Trade/Advanced/RightPanel/index.tsx
+++ b/components/Trade/Advanced/RightPanel/index.tsx
@@ -59,7 +59,7 @@ type MIProps = {
 const MarketInfo: React.FC<MIProps> = styled(
     ({
         lastPrice,
-        fairPrice,
+        // fairPrice,
         oraclePrice,
         fundingRate,
         // nextFunding,
@@ -70,7 +70,7 @@ const MarketInfo: React.FC<MIProps> = styled(
         return (
             <div className={className}>
                 <TitledBox title={'Last Price'}>{toApproxCurrency(lastPrice)}</TitledBox>
-                <TitledBox title={'Mark Price'}>{toApproxCurrency(fairPrice)}</TitledBox>
+                {/*<TitledBox title={'Mark Price'}>{toApproxCurrency(fairPrice)}</TitledBox>*/}
                 <TitledBox title={'Oracle Price'}>{toApproxCurrency(oraclePrice)}</TitledBox>
                 <TitledBox title={'Funding Rate'}>
                     <FundingRateGraphic rate={fundingRate} />


### PR DESCRIPTION
### Motivation

Rename 'mark price' to 'last price'

### Changes

- All instances of 'mark price' are removed from the front end. Only 'Last Price' and 'Oracle Price' are shown
- The 'mark price' instance in the 'position' component (bottom of screen) is renamed to 'last price' and displays the last price
