### PR TITLE
set max cumulative after calculation of rows

### DIFF
--- a/components/OrderBook/index.tsx
+++ b/components/OrderBook/index.tsx
@@ -51,7 +51,12 @@ export default styled(({ askOrders, bidOrders, lastTradePrice, marketUp, classNa
                     </BookRow>
                 );
             } // return an empty row
-            const rows = [];
+            const rows: {
+                bid: boolean,
+                price: number,
+                cumulative: number,
+                quantity: number
+            }[] = [];
             let cumulative = 0;
             let missedBracket = 0;
 
@@ -106,14 +111,15 @@ export default styled(({ askOrders, bidOrders, lastTradePrice, marketUp, classNa
                 }
             }
             const maxCumulative = sumQuantities(rows);
-            const withSetMax = rows.map((row) => 
-                <Order 
-                    maxCumulative={maxCumulative}
-                    bid={row.bid}
-                    price={row.price}
-                    cumulative={row.cumulative}
-                    quantity={row.quantity}
-                />
+            const withSetMax = rows.map((row) => (
+                    <Order 
+                        maxCumulative={maxCumulative}
+                        bid={row.bid}
+                        price={row.price}
+                        cumulative={row.cumulative}
+                        quantity={row.quantity}
+                    />
+                )
             )
             return !bid ? withSetMax.reverse() : withSetMax;
         },

--- a/components/OrderBook/index.tsx
+++ b/components/OrderBook/index.tsx
@@ -32,9 +32,9 @@ export default styled(({ askOrders, bidOrders, lastTradePrice, marketUp, classNa
         return orders.reduce((total, order) => total + order.quantity, 0);
     };
 
-    const totalAsks = sumQuantities(askOrders);
-    const totalBids = sumQuantities(bidOrders);
-    const maxCumulative = Math.max(totalAsks, totalBids);
+    // const totalAsks = sumQuantities(askOrders);
+    // const totalBids = sumQuantities(bidOrders);
+    // const maxCumulative = Math.max(totalAsks, totalBids);
 
     const deepCopyArrayOfObj = (arr: OMEOrder[]) => arr.map((order) => Object.assign({}, order));
 
@@ -54,6 +54,7 @@ export default styled(({ askOrders, bidOrders, lastTradePrice, marketUp, classNa
             const rows = [];
             let cumulative = 0;
             let missedBracket = 0;
+
             for (let i = 0; i < orders.length; i++) {
                 if (rows.length >= 8) {
                     break;
@@ -85,29 +86,36 @@ export default styled(({ askOrders, bidOrders, lastTradePrice, marketUp, classNa
                     }
                 }
                 cumulative += innerCumulative;
-                rows.push(
-                    <Order
-                        bid={bid}
-                        price={bracket}
-                        cumulative={cumulative}
-                        quantity={innerCumulative}
-                        maxCumulative={maxCumulative}
-                    />,
+                rows.push({
+                        bid: bid,
+                        price: bracket,
+                        cumulative: cumulative,
+                        quantity: innerCumulative,
+                    }
                 );
                 if (missedBracket) {
                     // this will be the very last order
                     rows.push(
-                        <Order
-                            bid={bid}
-                            price={missedBracket}
-                            cumulative={cumulative + orders[i].quantity}
-                            quantity={orders[i].quantity}
-                            maxCumulative={maxCumulative}
-                        />,
+                        {
+                            bid: bid,
+                            price: missedBracket,
+                            cumulative: cumulative + orders[i].quantity,
+                            quantity: orders[i].quantity
+                        }
                     );
                 }
             }
-            return !bid ? rows.reverse() : rows;
+            const maxCumulative = sumQuantities(rows);
+            const withSetMax = rows.map((row) => 
+                <Order 
+                    maxCumulative={maxCumulative}
+                    bid={row.bid}
+                    price={row.price}
+                    cumulative={row.cumulative}
+                    quantity={row.quantity}
+                />
+            )
+            return !bid ? withSetMax.reverse() : withSetMax;
         },
         [decimals],
     );

--- a/components/WhitelistBlock/index.tsx
+++ b/components/WhitelistBlock/index.tsx
@@ -8,7 +8,6 @@ export default styled(({ className, children }) => {
     const [validAddress, setValidAddress] = useState(false);
 
     useEffect(() => {
-        console.log('Address', account);
         if (whitelist.includes(account?.toLowerCase() ?? 'not-in-whitelist')) {
             setValidAddress(true);
         } else {


### PR DESCRIPTION
### Motivation

- someone placed a massive order at 0 so it was messing with the percentages displaying cumulative

### Changes

- display max cumulative after choosing rows 
