### PR TITLE
Use address as id

### DIFF
--- a/components/Insurance/Pools/index.tsx
+++ b/components/Insurance/Pools/index.tsx
@@ -1,8 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { TracerContext } from '@context/TracerContext';
 import { InsuranceContext } from '@context/InsuranceContext';
 import { defaults } from 'libs/Tracer/Insurance';
-import { useRouter } from 'next/router';
 import { InsurancePoolInfo, InsurancePoolInfo as InsurancePoolInfoType } from 'libs/types';
 import styled from 'styled-components';
 import { ProgressBar } from '@components/General';
@@ -148,7 +146,6 @@ const StyledIcon = styled(Icon)`
     border-right: 1px solid var(--color-accent);
 `;
 interface IPTProps {
-    handleClick: (tracerId: string) => void;
     pools: Record<string, InsurancePoolInfoType>;
     className?: string;
 }
@@ -249,32 +246,11 @@ const InsurancePoolsTable: React.FC<IPTProps> = styled(({ pools, className }: IP
  *
  */
 const Insurance: React.FC = () => {
-    const { setTracerId } = useContext(TracerContext);
     const { pools } = useContext(InsuranceContext);
-
-    const router = useRouter();
-    const query = router.query;
-
-    const handleClick = (tracerId: string) => {
-        router.push({
-            pathname: '/insurance',
-            query: { tracer: tracerId.split('/').join('-') },
-        });
-    };
-
-    useEffect(() => {
-        if (query.tracer) {
-            setTracerId
-                ? setTracerId(query.tracer.toString().split('-').join('/'))
-                : console.error('setTracerId not set');
-        } else {
-            setTracerId ? setTracerId('') : console.error('setTracerId not set');
-        }
-    }, [query]);
 
     return (
         <div className="h-full w-full flex flex-col">
-            <InsurancePoolsTable pools={pools ?? {}} handleClick={handleClick} />
+            <InsurancePoolsTable pools={pools ?? {}} />
         </div>
     );
 };

--- a/components/Trade/Advanced/TradingPanel/MarketSelect/index.tsx
+++ b/components/Trade/Advanced/TradingPanel/MarketSelect/index.tsx
@@ -30,7 +30,7 @@ const MarketSelectDropdown: React.FC<MarketSelectDropdownProps> = styled(
                     <Box
                         className="market"
                         key={`tracer-market-${tracer.marketId}`}
-                        onClick={() => onMarketSelect(tracer.marketId)}
+                        onClick={() => onMarketSelect(tracer.address)}
                     >
                         <MarketContainer className="w-1/4">
                             <SLogo ticker={tracer.baseTicker} />

--- a/context/FactoryContext.tsx
+++ b/context/FactoryContext.tsx
@@ -108,7 +108,7 @@ export const FactoryStore: React.FC<Children> = ({ children }: Children) => {
                 const _labelledTracers: LabelledTracers = tracers.reduce(
                     (o: any, t: { marketId: string; id: string }) => ({
                         ...o,
-                        [t.marketId]: {
+                        [t.id]: {
                             ...new Tracer(web3, t.id, t.marketId),
                             loading: false,
                         },

--- a/context/OrderContext.tsx
+++ b/context/OrderContext.tsx
@@ -190,7 +190,7 @@ export type OrderAction =
  */
 export const OrderStore: React.FC<Children> = ({ children }: Children) => {
     const { account } = useWeb3();
-    const { setTracerId, tracerId, selectedTracer } = useContext(TracerContext);
+    const { tracerId, selectedTracer } = useContext(TracerContext);
     const { omeState } = useContext(OMEContext);
 
     useEffect(() => {
@@ -450,11 +450,6 @@ export const OrderStore: React.FC<Children> = ({ children }: Children) => {
             }
         }
     }, [order.exposure, order.oppositeOrders]);
-
-    useEffect(() => {
-        // Handles setting the selected tracer Id on a market or collateral change
-        setTracerId ? setTracerId(`${order.market}/${order.collateral}`) : console.error('Error setting tracerId');
-    }, [order.market, order.collateral]);
 
     useEffect(() => {
         // sets the next position when exposire, price or the users base balance changes

--- a/context/TracerContext.tsx
+++ b/context/TracerContext.tsx
@@ -258,7 +258,7 @@ export const SelectedTracerStore: React.FC<StoreProps> = ({ tracer, children }: 
         }
     }, [selectedTracer]);
 
-    const tracerId = selectedTracer?.marketId;
+    const tracerId = selectedTracer?.id;
 
     return (
         <TracerContext.Provider

--- a/libs/Graph/hooks/Tracer.ts
+++ b/libs/Graph/hooks/Tracer.ts
@@ -38,8 +38,6 @@ export const useAllTracers: () => Tracers = () => {
         },
     });
 
-    console.log(data?.tracers);
-
     return {
         tracers: data?.tracers ?? ref.current,
         error,

--- a/libs/Graph/hooks/Tracer.ts
+++ b/libs/Graph/hooks/Tracer.ts
@@ -7,7 +7,7 @@ import { toBigNumbers } from '@libs/utils';
 
 const ALL_TRACERS = gql`
     query {
-        tracers {
+        tracers(first: 2, orderBy: timestamp, orderDirection: desc) {
             id
             marketId
         }
@@ -37,6 +37,8 @@ export const useAllTracers: () => Tracers = () => {
             }
         },
     });
+
+    console.log(data?.tracers);
 
     return {
         tracers: data?.tracers ?? ref.current,


### PR DESCRIPTION
### Motivation

- use address as id instead of marketId

### Changes

- removing of pools router setting of selected tracer
- use address in labelled tracers
- wherever setTracerId is called us id
- only fetch top two markets ordered by timestamp
