### PR TITLE
Keep margin buttons

### DIFF
--- a/components/Trade/Advanced/TradingPanel/Account/index.tsx
+++ b/components/Trade/Advanced/TradingPanel/Account/index.tsx
@@ -126,7 +126,7 @@ const AccountPanel: FC<APProps> = ({ selectedTracer, account, order }: APProps) 
                 </h3>
                 <AvailableMargin order={order} balances={balances} maxLeverage={maxLeverage} fairPrice={fairPrice} />
             </Item>
-            <DepositWithdraw hide={!!order?.exposureBN?.toNumber() ?? false}>
+            <DepositWithdraw>
                 <Button
                     className={balances.quote.eq(0) ? 'primary' : ''}
                     onClick={(_e: any) => handleClick(true, true)}
@@ -191,10 +191,10 @@ const Item = styled.div`
     }
 `;
 
-const DepositWithdraw = styled.div<{ hide: boolean }>`
+const DepositWithdraw = styled.div`
+    display: flex;
     margin-top: 1rem;
     justify-content: space-between;
-    display: ${(props) => (props.hide ? 'none' : 'flex')};
 `;
 
 const AccountInfo = styled(Box)<{ zeroBalance: boolean }>`


### PR DESCRIPTION
### Motivation

When making a trade it removes the deposit and withdraw buttons to save space. This can be confusing for the user when it asks them to deposit more margin.

### Changes

Unhide margin buttons that were previously hidden while placing trades
