### PR TITLE
Leverage slider freezes

### DIFF
--- a/context/OrderContext.tsx
+++ b/context/OrderContext.tsx
@@ -277,7 +277,7 @@ export const OrderStore: React.FC<Children> = ({ children }: Children) => {
                         position: action.leverage < 0 ? SHORT : action.leverage > 0 ? LONG : state.position,
                     };
                 }
-                const targetLeverage = new BigNumber(action.leverage);
+                let targetLeverage = new BigNumber(!Number.isNaN(action.leverage) ? action.leverage : 0);
                 let addedExposure;
                 if (targetLeverage.eq(0)) {
                     addedExposure = base.abs();
@@ -435,12 +435,7 @@ export const OrderStore: React.FC<Children> = ({ children }: Children) => {
         // calculate the exposure based on the opposite orders
         if (order.orderType === MARKET && order.oppositeOrders.length) {
             // convert orders
-            const { slippage, tradePrice } = calcSlippage(
-                order.exposureBN,
-                // TODO remove this, its because we used to factor in leverage per trade ie 2x would double exposure
-                new BigNumber(1),
-                order.oppositeOrders,
-            );
+            const { slippage, tradePrice } = calcSlippage(order.exposureBN, order.oppositeOrders);
             if (!slippage.eq(0)) {
                 orderDispatch({ type: 'setSlippage', value: slippage.toNumber() });
             } else {

--- a/context/OrderContext.tsx
+++ b/context/OrderContext.tsx
@@ -277,7 +277,7 @@ export const OrderStore: React.FC<Children> = ({ children }: Children) => {
                         position: action.leverage < 0 ? SHORT : action.leverage > 0 ? LONG : state.position,
                     };
                 }
-                let targetLeverage = new BigNumber(!Number.isNaN(action.leverage) ? action.leverage : 0);
+                const targetLeverage = new BigNumber(!Number.isNaN(action.leverage) ? action.leverage : 0);
                 let addedExposure;
                 if (targetLeverage.eq(0)) {
                     addedExposure = base.abs();

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "@portis/web3": "^4.0.0",
         "@tracer-protocol/contracts": "^0.2.12",
         "@tracer-protocol/onboard": "^1.29.2",
-        "@tracer-protocol/tracer-utils": "^0.2.27",
+        "@tracer-protocol/tracer-utils": "^0.2.29",
         "@walletconnect/web3-provider": "^1.1.0",
         "@xstate/react": "^1.3.1",
         "antd": "^4.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3407,10 +3407,10 @@
     tslib "^2.1.0"
     web3 "^1.3.4"
 
-"@tracer-protocol/tracer-utils@^0.2.27":
-  version "0.2.27"
-  resolved "https://registry.yarnpkg.com/@tracer-protocol/tracer-utils/-/tracer-utils-0.2.27.tgz#9a1e8847b95f8a2f4dba1758ceeea0611de88067"
-  integrity sha512-MWTI8Oom3DfEJcYMq3wsyXgBzMmYtSFGv4z9DjU+4AbgrfpZtfqS06NWuCp9sCrK5eNjTHypSpNdh31+iW1bmA==
+"@tracer-protocol/tracer-utils@^0.2.29":
+  version "0.2.29"
+  resolved "https://registry.yarnpkg.com/@tracer-protocol/tracer-utils/-/tracer-utils-0.2.29.tgz#3cbd2863b313588e3e98516f453a74d939358873"
+  integrity sha512-KQvi+y10GFMBhMFpMe07ZaC6vKpIoklA9gYnZRr9/Z/yNIHL5JWv7+U4kXiSIAy9kox5DOE3EsysWzQQXmZpcQ==
   dependencies:
     "@types/node" "^14.14.37"
     bignumber.js "^9.0.1"


### PR DESCRIPTION
### Motivation

When entering bad leverage input calcSlippage would return NaN values causing all values to freeze and not update exposureAmount

### Changes

- update utils version
- add check for added leverage input
