### PR TITLE
Disable account button during on-boarding

### DIFF
--- a/components/Nav/Navbar/AccountDropdown.tsx
+++ b/components/Nav/Navbar/AccountDropdown.tsx
@@ -26,6 +26,7 @@ export default (({ account, onboard, ensName, logout, handleConnect, tokenBalanc
         <StyledDropdown className={open ? 'open' : ''} id="account-dropdown">
             <MainButton>
                 <AccountDropdown
+                    id="account-dropdown-button"
                     className={!open ? 'show-hover' : ''}
                     onClick={async () => {
                         if (!!account) {

--- a/components/Trade/TourSteps/index.tsx
+++ b/components/Trade/TourSteps/index.tsx
@@ -51,18 +51,26 @@ export const tourConfig = [
         },
         // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
         action: () => {
+            const accountDropdownButton = document.getElementById('account-dropdown-button');
+            if (accountDropdownButton) {
+                accountDropdownButton.style.pointerEvents = 'none';
+            }
+
             const calculatorEl = document.getElementById('calculator-modal') as HTMLElement;
-            const marginModalEl = document.getElementById('account-modal') as HTMLElement;
             if (calculatorEl) {
                 calculatorEl.style.display = 'block';
             }
+
+            const marginModalEl = document.getElementById('account-modal') as HTMLElement;
             if (marginModalEl) {
                 marginModalEl.style.display = 'block';
             }
+
             const calculatorButton = document.getElementById('calculator-button') as HTMLElement;
             if (calculatorButton) {
                 calculatorButton.style.zIndex = '0';
             }
+
             const depositButton = document.getElementById('deposit-button') as HTMLElement;
             if (depositButton) {
                 depositButton.style.zIndex = '0';

--- a/components/Trade/index.tsx
+++ b/components/Trade/index.tsx
@@ -108,6 +108,12 @@ const Advanced: React.FC = styled(({ className }) => {
 
         // Reset the elements affected by the tour
 
+        // Reset account dropdown button pointer events
+        const accountDropdownButton = document.getElementById('account-dropdown-button');
+        if (accountDropdownButton) {
+            accountDropdownButton.style.pointerEvents = 'auto';
+        }
+
         // Show the 'No Position Open' again
         const positionOverlay = document.getElementById('position-overlay') as HTMLElement;
         if (positionOverlay) {


### PR DESCRIPTION
### Motivation

Should not let the user press their 'account' during the tutorial

### Changes

Disable account dropdown button during the onboarding tutorial